### PR TITLE
Fix path to database in nix-locate

### DIFF
--- a/src/bin/nix-locate.rs
+++ b/src/bin/nix-locate.rs
@@ -64,7 +64,7 @@ fn locate(args: &Args) -> Result<()> {
     };
 
     // Open the database
-    let index_file = args.database.join("files.zst");
+    let index_file = args.database.join("files");
     let mut db = database::Reader::open(&index_file).chain_err(|| ErrorKind::ReadDatabase(index_file.clone()))?;
 
     let results = db.find_iter(&pattern)


### PR DESCRIPTION
Otherwise `nix-locate` can't find the db. Looks like an oversight after https://github.com/bennofs/nix-index/commit/df38f0fa1621e7b9274a61f9004ac960bbabf4cc.