### PR TITLE
Add NIX_AUTO_RUN/NIX_AUTO_INSTALL handling

### DIFF
--- a/command-not-found.sh
+++ b/command-not-found.sh
@@ -65,9 +65,9 @@ The program '$cmd' is currently not installed. It is provided by
 several packages. You can install it by typing one of the following:
 EOF
 
-	          for attr in $(echo $attrs); do
+	          while read attr; do
                 >&2 echo "  nix-env -iA $toplevel.$attr"
-	          done
+	          done <<< "$attrs"
             ;;
     esac
 

--- a/command-not-found.sh
+++ b/command-not-found.sh
@@ -4,8 +4,18 @@
 # this will be called when a command is entered
 # but not found in the user’s path + environment
 command_not_found_handle () {
-    toplevel=nixos # TODO: detect this somehow
-    cmd=$1 # TODO: differentiate between paths and commands
+
+    # TODO: use "command not found" gettext translations
+
+    # taken from http://www.linuxjournal.com/content/bash-command-not-found
+    # - do not run when inside Midnight Commander or within a Pipe
+    if [ -n "$MC_SID" ] || ! [ -t 1 ]; then
+        >&2 echo "$1: command not found"
+        return 127
+    fi
+
+    toplevel=nixpkgs # nixpkgs should always be available even in NixOS
+    cmd=$1
     attrs=$(@out@/bin/nix-locate --minimal --no-group --type x --top-level --whole-name --at-root "/bin/$cmd")
     len=$(echo -n "$attrs" | grep -c "^")
 

--- a/command-not-found.sh
+++ b/command-not-found.sh
@@ -65,9 +65,9 @@ The program '$cmd' is currently not installed. It is provided by
 several packages. You can install it by typing one of the following:
 EOF
 
-	          while read attr; do
+            while read attr; do
                 >&2 echo "  nix-env -iA $toplevel.$attr"
-	          done <<< "$attrs"
+            done <<< "$attrs"
             ;;
     esac
 


### PR DESCRIPTION
This adds in the autorun/autoinstall handling for the bash scripts.

I've also fixed a change to the multiple args handling that broke ZSH scripts. The new fix should work in both Bash and ZSH.

Some other formatting changes as well.