### PR TITLE
default.nix: Use newer nixpkgs/Rust infrastructure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,30 +1,18 @@
 let
-  # nixpkgs-unstable at 2017-07-21 12:12
-  nixpkgsRev = "1d78df27294017d464e60bf9b0595e7e42cfca55";
+  # nixpkgs-unstable at 2018-08-20 14:43
+  nixpkgsRev = "0828e2d8c369604c56219bd7085256b984087280";
   defaultNixpkgs = builtins.fetchTarball "github.com/NixOS/nixpkgs/archive/${nixpkgsRev}.tar.gz";
 in
 { nixpkgs ? defaultNixpkgs }:
 
 with (import nixpkgs {}); with rustPlatform;
 
-let
-  registry = rustRegistry.overrideAttrs (old: {
-    name = "rustRegistry-2017-07-21";
-    src = fetchFromGitHub {
-      owner = "rust-lang";
-      repo = "crates.io-index";
-      rev = "25ee65416ccd75fd0bdbcc31affb119513dd2951";
-      sha256 = "1y2mlj31xpzw5h2l4rl1r74gc58lagqsmcmfj0fjgmjzv7glqcwz";
-    };
-  });
-in buildRustPackage rec {
+buildRustPackage rec {
   name = "nix-index-${version}";
-  version = "0.1.0";
-
-  rustRegistry = registry;
+  version = "0.1.1";
 
   src = builtins.filterSource (name: type: !lib.hasPrefix "target" (baseNameOf name) && !lib.hasPrefix "result" (baseNameOf name) && name != ".git") ./.;
-  depsSha256 = "0v145fi9bfiwvsdy7hz9lw4m2f2j8sxvixfzmjwfnq4klm51c8yl";
+  cargoSha256 = "10zb7kbqiwpmx7kcp7pxxr1w311cgpi3x8qv0wi5lqmp0hsshx6s";
   buildInputs = [pkgconfig openssl curl];
 
   postInstall = ''


### PR DESCRIPTION
The Rust infrastructure in nixpkgs used to require explicitly
identifying a crates.io registry version to pull crates from.

Now it always fetches the current registry instead, but requires that
the sources identified by the package's Cargo.lock have a known
fixed-output hash.

So this commit updates default.nix to use a recent-enough nixpkgs (I
chose the last commit that touched Rust-related bits) and fixes the hash
for the current Cargo.lock.

Fixes #21.