### PR TITLE
fix(hydra.rs): matching on regular filetype

### DIFF
--- a/src/hydra.rs
+++ b/src/hydra.rs
@@ -653,7 +653,7 @@ impl<'de> Deserialize<'de> for HydraFileListing {
 
 
                 match typ {
-                    b"byte" => {
+                    b"regular" => {
                         let size = size.ok_or_else(|| serde::de::Error::missing_field("size"))?;
                         let executable = executable.unwrap_or(false);
                         Ok(FileTree::regular(size, executable))


### PR DESCRIPTION
Hi,

I am testing nix-index on an M1 following the merge of #170 and 5a4b3c603b837ded17845c59227dd06312562782, and I get a strange error:

```
Error: fetching the file listing for store path '/nix/store/il7xvxgrysy8375mh2rsdpxsp758r0vz-unix-time-0.4.7-doc' failed
Caused by: response to GET 'http://cache.nixos.org/il7xvxgrysy8375mh2rsdpxsp758r0vz.ls' failed to parse (response saved to /var/folders/q0/7nd9ll396h9cvnw3fwgty6k40000gn/T/file_listing.json.1062)
Caused by: unknown variant `regular`, expected one of `regular`, `directory`, `symlink` at line 1 column 232
generating index: 00002 paths found :: 22082 paths not in binary cache :: 42024 paths in queue
```

This error occurs with every derivation.

The content of the file listing is normal, valid JSON:
``` json
{
  "version": 1,
  "root": {
    "type": "directory",
    "entries": {
      "share": {
        "type": "directory",
        "entries": {
          "doc": {
            "type": "directory",
            "entries": {
              "unix-time-0.4.7": {
                "type": "directory",
                "entries": {
                  "LICENSE": {
                    "type": "regular",
                    "size": 1525,
                    "narOffset": 648
                  },
                  "html": {
                    "type": "directory",
                    "entries": {
                      "Data-UnixTime.html": {
                        "type": "regular",
                        "size": 62984,
                        "narOffset": 2512
                      },
                      "doc-index.html": {
                        "type": "regular",
                        "size": 5218,
                        "narOffset": 65688
                      },
  ... <snipped/>
}
```

Looking at the changes done in #170, I believe an error was introduced on line 656:
https://github.com/bennofs/nix-index/blob/5a4b3c603b837ded17845c59227dd06312562782/src/hydra.rs#L655-L661

This PR resolves this issue.

``` console
[nberbiche:~] $ nix-index
+ querying available packages
+ generating index: 38244 paths found :: 27342 paths not in binary cache :: 04013 paths in queue
Error: fetching the file listing for store path '/nix/store/siv7varixjdfjs17i3qfrvyc072rx55j-ia-writer-duospace-20180721' failed
Caused by: response to GET 'http://cache.nixos.org/siv7varixjdfjs17i3qfrvyc072rx55j.ls' failed to parse (response saved to /var/folders/q0/7nd9ll396h9cvnw3fwgty6k40000gn/T/file_listing.json.1063)
Caused by: expected value at line 1 column 1
+ generating index: 41718 paths found :: 28594 paths not in binary cache :: 00000 paths in queue
+ wrote index of 14,533,214 bytes
[nberbiche:~] 3m31s $
```