### PR TITLE
add some fixes for Darwin and Flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,9 +3,9 @@ let
   nixpkgsRev = "8e1eab9eae4278c9bb1dcae426848a581943db5a";
   defaultNixpkgs = builtins.fetchTarball "github.com/NixOS/nixpkgs/archive/${nixpkgsRev}.tar.gz";
 in
-{ nixpkgs ? defaultNixpkgs }:
+{ nixpkgs ? defaultNixpkgs, pkgs ? import nixpkgs {}, ... }:
 
-with (import nixpkgs {}); with rustPlatform;
+with pkgs; with rustPlatform;
 
 buildRustPackage rec {
   name = "nix-index-${version}";

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ buildRustPackage rec {
   version = "0.1.3";
 
   src = builtins.filterSource (name: type: !lib.hasPrefix "target" (baseNameOf name) && !lib.hasPrefix "result" (baseNameOf name) && name != ".git") ./.;
-  buildInputs = [openssl curl];
+  buildInputs = [openssl curl] ++ lib.optional pkgs.targetPlatform.isDarwin [pkgs.darwin.apple_sdk.frameworks.Security pkgs.libiconv];
   nativeBuildInputs = [ pkg-config ];
 
   cargoLock = {

--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,8 @@ buildRustPackage rec {
     lockFile = ./Cargo.lock;
   };
 
+  doCheck = !pkgs.targetPlatform.isDarwin;
+
   postInstall = ''
     mkdir -p $out/etc/profile.d
     cp ${./command-not-found.sh} $out/etc/profile.d/command-not-found.sh


### PR DESCRIPTION
altogether, these changes allow you to do things like `final.callPackage sources.nix-index { };` in a Nix Flake.

I disabled checks here since they appear to be system-dependent (they pass on Linux, but not on Darwin.) The same logic is applied in nixpkgs.