### PR TITLE
feat: added prefix filtering support

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -62,12 +62,17 @@ impl Writer {
     }
 
     /// Add a new package to the database for the given store path with its corresponding
-    /// file tree.
-    pub fn add(&mut self, path: StorePath, files: FileTree) -> io::Result<()> {
+    /// file tree. Entries are only added if they match `filter_prefix`.
+    pub fn add(
+        &mut self,
+        path: StorePath,
+        files: FileTree,
+        filter_prefix: &[u8],
+    ) -> io::Result<()> {
         let writer = self.writer.as_mut().expect("not dropped yet");
         let mut encoder =
             frcode::Encoder::new(writer, b"p".to_vec(), serde_json::to_vec(&path).unwrap());
-        for entry in files.to_list() {
+        for entry in files.to_list(filter_prefix) {
             entry.encode(&mut encoder)?;
         }
         Ok(())

--- a/src/files.rs
+++ b/src/files.rs
@@ -215,7 +215,7 @@ impl FileTree {
         })
     }
 
-    pub fn to_list(&self) -> Vec<FileTreeEntry> {
+    pub fn to_list(&self, filter_prefix: &[u8]) -> Vec<FileTreeEntry> {
         let mut result = Vec::new();
 
         let mut stack = Vec::with_capacity(16);
@@ -235,10 +235,9 @@ impl FileTree {
                     stack.push((path, entry));
                 }
             }
-            result.push(FileTreeEntry {
-                path: path,
-                node: node,
-            });
+            if path.starts_with(filter_prefix) {
+                result.push(FileTreeEntry { path, node });
+            }
         }
         result
     }


### PR DESCRIPTION
Added a way to only put paths starting with a certain prefix into the database, through a `--filter-prefix` flag. Should resolve #176, and is a way to solve NixOS/nixpkgs#39789.

```
--filter-prefix <PREFIX>    Only add paths starting with PREFIX (e.g. `/bin/`)
```

Some typos were also fixed.