### PR TITLE
nix-index: xlibs has become xorg in recent Nixpkgs

### DIFF
--- a/src/bin/nix-index.rs
+++ b/src/bin/nix-index.rs
@@ -202,7 +202,7 @@ async fn update_index(args: &Args) -> Result<()> {
             // We only need sets that are not marked "recurseIntoAttrs" here, since if they are,
             // they are already part of normal_paths.
             let extra_scopes = [
-                "xlibs",
+                "xorg",
                 "haskellPackages",
                 "rPackages",
                 "nodePackages",


### PR DESCRIPTION
Fixes https://github.com/bennofs/nix-index/issues/178.

Thanks @hqurve for finding exactly where this needed to be changed :)