### PR TITLE
nix-index: add option to specify system platform

### DIFF
--- a/src/nixpkgs.rs
+++ b/src/nixpkgs.rs
@@ -24,6 +24,7 @@ use crate::package::{PathOrigin, StorePath};
 /// The function returns an Iterator over the packages returned by nix-env.
 pub fn query_packages(
     nixpkgs: &str,
+    system: &str,
     scope: Option<&str>,
     show_trace: bool,
 ) -> PackagesQuery<ChildStdout> {
@@ -39,6 +40,10 @@ pub fn query_packages(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .stdin(Stdio::null());
+
+    if !system.is_empty() {
+        cmd.arg("--argstr").arg("system").arg(system);
+    }
 
     if let Some(scope) = scope {
         cmd.arg("-A").arg(scope);


### PR DESCRIPTION
This allows the command `nix-index` to build indices for foreign system platforms regardless of the host one by using `nix-env --argstr system <platform>`, which might be useful for multiarch or cross-compile settings.

My own fork of [`nix-index-database`](https://github.com/usertam/nix-index-database) (which builds indices weekly) exploited this to eliminate the need for platform setup/emulations, and by merging this I am hoping to cache the binaries and further reduce the build time of indices. :D