### PR TITLE
add aarch64-linux build target for flakes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
   };
 
   outputs = { self, nixpkgs, flake-compat }: let
-    systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
     nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
   in {


### PR DESCRIPTION
Building for aarch64-linux seems to just work.  But to expose the package in the flake it is necessary to add the aarch64-linux build target to the flake.nix