### PR TITLE
Move from clap-v2 to clap-v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,15 +28,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -172,17 +163,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
 dependencies = [
- "ansi_term 0.11.0",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6db9e867166a43a53f7199b5e4d1f522a1e5bd626654be263c999ce59df39a"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -567,6 +582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,7 +858,7 @@ dependencies = [
 name = "nix-index"
 version = "0.1.3"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "atty",
  "bincode",
  "brotli2",
@@ -901,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "opaque-debug"
@@ -943,6 +964,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "parking_lot"
@@ -1018,6 +1045,30 @@ name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1302,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1342,12 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thread_local"
@@ -1514,12 +1562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,12 +1584,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Benno Fünfstück <benno.fuenfstueck@gmail.com>"]
-edition = "2018"
+edition = "2021"
 name = "nix-index"
 version = "0.1.3"
 [[bin]]
@@ -15,7 +15,6 @@ ansi_term = "0.12.1"
 bincode = "1.3.3"
 brotli2 = "0.3.2"
 byteorder = "1.4.3"
-clap = "2.33.3"
 error-chain = "0.12.4"
 futures = "0.3.17"
 grep = "0.2.8"
@@ -49,6 +48,10 @@ version = "0.14.15"
 [dependencies.tokio]
 features = ["full"]
 version = "1.14.0"
+
+[dependencies.clap]
+version = "3.2.6"
+features = ["derive"]
 
 [[example]]
 name = "nix-index-debug"

--- a/src/bin/nix-locate.rs
+++ b/src/bin/nix-locate.rs
@@ -1,15 +1,16 @@
 //! Tool for searching for files in nixpkgs packages
 use ansi_term::Colour::Red;
-use clap::{crate_authors, crate_version};
-use clap::{App, Arg, ArgMatches};
+use clap::Parser;
 use error_chain::error_chain;
 use regex::bytes::Regex;
 use separator::Separatable;
 use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::process;
 use std::result;
 use std::str;
+use std::str::FromStr;
 use stderr::{err, errln};
 
 use nix_index::database;
@@ -151,20 +152,15 @@ fn locate(args: &Args) -> Result<()> {
 /// Extract the parsed arguments for clap's arg matches.
 ///
 /// Handles parsing the values of more complex arguments.
-fn process_args(matches: &ArgMatches) -> result::Result<Args, clap::Error> {
-    let pattern_arg = matches
-        .value_of("PATTERN")
-        .expect("pattern arg required")
-        .to_string();
-    let package_arg = matches.value_of("package");
-    let start_anchor = if matches.is_present("at-root") {
-        "^"
-    } else {
-        ""
-    };
-    let end_anchor = if matches.is_present("whole") { "$" } else { "" };
+fn process_args(matches: Opts) -> result::Result<Args, clap::Error> {
+    let pattern_arg = matches.pattern;
+    let package_arg = matches.package;
+
+    let start_anchor = if matches.at_root { "^" } else { "" };
+    let end_anchor = if matches.whole_name { "$" } else { "" };
+
     let make_pattern = |s: &str, wrap: bool| {
-        let regex = if matches.is_present("regex") {
+        let regex = if matches.regex {
             s.to_string()
         } else {
             regex::escape(s)
@@ -175,51 +171,30 @@ fn process_args(matches: &ArgMatches) -> result::Result<Args, clap::Error> {
             regex
         }
     };
-    let color = matches.value_of("color").and_then(|x| {
-        if x == "auto" {
-            return None;
-        }
-        if x == "always" {
-            return Some(true);
-        }
-        if x == "never" {
-            return Some(false);
-        }
-        unreachable!("color can only be auto, always or never (verified by clap already)")
-    });
+
+    let color = match matches.color {
+        Color::Auto => atty::is(atty::Stream::Stdout),
+        Color::Always => true,
+        Color::Never => false,
+    };
+
     let args = Args {
-        database: PathBuf::from(
-            matches
-                .value_of("database")
-                .expect("database has default value by clap"),
-        ),
-        group: !matches.is_present("no-group"),
+        database: matches.database,
+        group: !matches.no_group,
         pattern: make_pattern(&pattern_arg, true),
-        package_pattern: package_arg.map(|p| make_pattern(p, false)),
-        hash: matches.value_of("hash").map(str::to_string),
+        package_pattern: package_arg.as_deref().map(|p| make_pattern(p, false)),
+        hash: matches.hash,
         file_type: matches
-            .values_of("type")
-            .map_or(files::ALL_FILE_TYPES.to_vec(), |types| {
-                types
-                    .map(|t| match t {
-                        "x" => FileType::Regular { executable: true },
-                        "r" => FileType::Regular { executable: false },
-                        "s" => FileType::Symlink,
-                        "d" => FileType::Directory,
-                        _ => unreachable!(
-                            "file type can only be one of x, r, s and d (verified by clap already)"
-                        ),
-                    })
-                    .collect()
-            }),
-        only_toplevel: matches.is_present("toplevel"),
-        color: color.unwrap_or_else(|| atty::is(atty::Stream::Stdout)),
-        minimal: matches.is_present("minimal"),
+            .r#type
+            .unwrap_or_else(|| files::ALL_FILE_TYPES.to_vec()),
+        only_toplevel: matches.top_level,
+        color,
+        minimal: matches.minimal,
     };
     Ok(args)
 }
 
-const LONG_USAGE: &'static str = r#"
+const LONG_USAGE: &str = r#"
 How to use
 ==========
 
@@ -249,88 +224,100 @@ Limitations
   but we know that `xmonad-with-packages.out` requires it.
 "#;
 
-fn main() {
+fn cache_dir() -> &'static OsStr {
     let base = xdg::BaseDirectories::with_prefix("nix-index").unwrap();
-    let cache_dir = base.get_cache_home();
-    let cache_dir = cache_dir.to_string_lossy();
+    let cache_dir = Box::new(base.get_cache_home());
+    let cache_dir = Box::leak(cache_dir);
+    cache_dir.as_os_str()
+}
 
-    let matches = App::new("Nixpkgs Files Indexer")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about("Quickly finds the derivation providing a certain file")
-        .arg(Arg::with_name("database")
-             .short("d")
-             .long("db")
-             .default_value(&cache_dir)
-             .help("Directory where the index is stored"))
-        .arg(Arg::with_name("PATTERN")
-             .required(true)
-             .help("Pattern for which to search")
-             .index(1))
-        .arg(Arg::with_name("regex")
-             .short("r")
-             .long("regex")
-             .help("Treat PATTERN as regex instead of literal text. Also applies to --name option."))
-        .arg(Arg::with_name("package")
-             .short("p")
-             .long("package")
-             .value_name("PATTERN")
-             .help("Only print matches from packages whose name matches PATTERN."))
-        .arg(Arg::with_name("hash")
-             .long("hash")
-             .value_name("HASH")
-             .help("Only print matches from the package that has the given HASH."))
-        .arg(Arg::with_name("toplevel")
-             .long("top-level")
-             .help("Only print matches from packages that show up in nix-env -qa."))
-        .arg(Arg::with_name("type")
-             .short("t")
-             .long("type")
-             .multiple(true)
-             .number_of_values(1)
-             .value_name("TYPE")
-             .possible_values(&["d", "x", "r", "s"])
-             .help("Only print matches for files that have this type.\
-                    If the option is given multiple times, a file will be printed if it has any of the given types."
-             ))
-         .arg(Arg::with_name("no-group")
-              .long("no-group")
-              .help("Disables grouping of paths with the same matching part. \n\
-                     By default, a path will only be printed if the pattern matches some part\n\
-                     of the last component of the path. For example, the pattern `a/foo` would\n\
-                     match all of `a/foo`, `a/foo/some_file` and `a/foo/another_file`, but only\n\
-                     the first match will be printed. This option disables that behavior and prints\n\
-                     all matches."
-              ))
-        .arg(Arg::with_name("color")
-             .multiple(false)
-             .value_name("COLOR")
-             .possible_values(&["always", "never", "auto"])
-             .help("Whether to use colors in output. If auto, only use colors if outputting to a terminal."))
-        .arg(Arg::with_name("whole")
-             .short("w")
-             .long("whole-name")
-             .help("Only print matches for files or directories whose basename matches PATTERN exactly.\n\
-                    This means that the pattern `bin/foo` will only match a file called `bin/foo` or `xx/bin/foo`\n\
-                    but not `bin/foobar`."
-             ))
-        .arg(Arg::with_name("at-root")
-            .long("at-root")
-            .help("Treat PATTERN as an absolute file path, so it only matches starting from the root of a package.\n\
-                   This means that the pattern `/bin/foo` only matches a file called `/bin/foo` or `/bin/foobar`\n\
-                   but not `/libexec/bin/foo`."
-            ))
-        .arg(Arg::with_name("minimal")
-             .short("1")
-             .long("minimal")
-             .help("Only print attribute names of found files or directories.\n\
-                    Other details such as size or store path are omitted.\n\
-                    This is useful for scripts that use the output of nix-locate."
-             ))
-        .after_help(LONG_USAGE)
-        .get_matches();
+/// Quickly finds the derivation providing a certain file
+#[derive(Debug, Parser)]
+#[clap(author, about, version, after_help = LONG_USAGE)]
+struct Opts {
+    /// Pattern for which to search
+    // #[clap(name = "PATTERN")]
+    pattern: String,
 
-    let args = process_args(&matches).unwrap_or_else(|e| e.exit());
+    /// Directory where the index is stored
+    #[clap(short, long = "db", default_value_os = cache_dir())]
+    database: PathBuf,
+
+    /// Treat PATTERN as regex instead of literal text. Also applies to NAME.
+    #[clap(short, long)]
+    regex: bool,
+
+    /// Only print matches from packages whose name matches PACKAGE.
+    #[clap(short, long)]
+    package: Option<String>,
+
+    /// Only print matches from the package that has the given HASH.
+    #[clap(long, name = "HASH")]
+    hash: Option<String>,
+
+    /// Only print matches from packages that show up in `nix-env -qa`.
+    #[clap(long)]
+    top_level: bool,
+
+    /// Only print matches for files that have this type. If the option is given multiple times, 
+    /// a file will be printed if it has any of the given types.
+    #[clap(short, long, possible_values=["d", "x", "r", "s"])]
+    r#type: Option<Vec<FileType>>,
+
+    /// Disables grouping of paths with the same matching part. By default, a path will only be
+    /// printed if the pattern matches some part of the last component of the path. For example,
+    /// the pattern `a/foo` would match all of `a/foo`, `a/foo/some_file` and `a/foo/another_file`,
+    /// but only the first match will be printed. This option disables that behavior and prints
+    /// all matches.
+    #[clap(long)]
+    no_group: bool,
+
+    /// Whether to use colors in output. If auto, only use colors if outputting to a terminal.
+    #[clap(long, arg_enum, default_value = "auto")]
+    color: Color,
+
+    /// Only print matches for files or directories whose basename matches PATTERN exactly.
+    /// This means that the pattern `bin/foo` will only match a file called `bin/foo` or
+    /// `xx/bin/foo` but not `bin/foobar`.
+    #[clap(short, long)]
+    whole_name: bool,
+
+    /// Treat PATTERN as an absolute file path, so it only matches starting from the root of a
+    /// package. This means that the pattern `/bin/foo` only matches a file called `/bin/foo` or
+    /// `/bin/foobar` but not `/libexec/bin/foo`.
+    #[clap(long)]
+    at_root: bool,
+
+    /// Only print attribute names of found files or directories. Other details such as size or
+    /// store path are omitted. This is useful for scripts that use the output of nix-locate.
+    #[clap(long)]
+    minimal: bool,
+}
+
+#[derive(clap::ArgEnum, Clone, Copy, Debug)]
+enum Color {
+    Always,
+    Never,
+    Auto,
+}
+
+impl FromStr for Color {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        match s {
+            "always" => Ok(Color::Always),
+            "never" => Ok(Color::Never),
+            "auto" => Ok(Color::Auto),
+            _ => Err(""),
+        }
+    }
+}
+
+fn main() {
+    let args = Opts::parse();
+
+    let args = process_args(args).unwrap_or_else(|e| e.exit());
 
     if let Err(e) = locate(&args) {
         errln!("error: {}", e);

--- a/src/files.rs
+++ b/src/files.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 use std::io::{self, Write};
-use std::str;
+use std::str::{self, FromStr};
 
 use crate::frcode;
 
@@ -58,11 +58,25 @@ pub enum FileNode<T> {
 /// An exception to this is the `executable` field for the regular type.
 /// This is needed since we present `regular` and `executable` files as different
 /// to the user, so we need a way to represent both types.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FileType {
     Regular { executable: bool },
     Directory,
     Symlink,
+}
+
+impl FromStr for FileType {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "r" => Ok(FileType::Regular { executable: false }),
+            "x" => Ok(FileType::Regular { executable: true }),
+            "d" => Ok(FileType::Directory),
+            "s" => Ok(FileType::Symlink),
+            _ => Err("invalid file type"),
+        }
+    }
 }
 
 /// This lists all file types that can currently be represented.


### PR DESCRIPTION
This PR updates clap to version 3, and uses clap's new `#[derive(Parser)]` feature to rely on clap more heavily for parsing args.

Also bump to the 2021 edition, to enable disjoint capture in closures.