### PR TITLE
feat: Set database location from NIX_INDEX_DATABASE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ version = "1.24.1"
 
 [dependencies.clap]
 version = "4.0.32"
-features = ["derive"]
+features = ["derive", "env"]
 
 [dependencies.rusqlite]
 features = ["backup"]

--- a/src/bin/nix-index.rs
+++ b/src/bin/nix-index.rs
@@ -120,7 +120,7 @@ struct Args {
     jobs: usize,
 
     /// Directory where the index is stored
-    #[clap(short, long = "db", default_value_os = cache_dir())]
+    #[clap(short, long = "db", default_value_os = cache_dir(), env = "NIX_INDEX_DATABASE")]
     database: PathBuf,
 
     /// Path to nixpkgs for which to build the index, as accepted by nix-env -f

--- a/src/bin/nix-locate.rs
+++ b/src/bin/nix-locate.rs
@@ -239,7 +239,7 @@ struct Opts {
     pattern: String,
 
     /// Directory where the index is stored
-    #[clap(short, long = "db", default_value_os = cache_dir())]
+    #[clap(short, long = "db", default_value_os = cache_dir(), env = "NIX_INDEX_DATABASE")]
     database: PathBuf,
 
     /// Treat PATTERN as regex instead of literal text. Also applies to NAME.


### PR DESCRIPTION
This allows setting the database location also via `NIX_INDEX_DATABASE`, since overriding `XDG_CACHE_HOME` might have unwanted side effects (cf. Mic92/nix-index-database#48). Fixes #143 and nix-community/comma#50.