### PR TITLE
feat(command-not-found): Support Nushell

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Or run it once with:
 
 A [`home-manager` module](https://nix-community.github.io/home-manager/options.html#opt-programs.nix-index.enable) is now available to integrate `nix-index` with `bash`, `zsh`, and `fish` using this script.
 
+You can also use `command-not-found.nu` as a Nushell hook by adding the
+following to your Nushell config:
+
+```nix
+  programs.nushell = {
+    enable = true;
+    extraConfig = ''
+      $env.config.hooks.command_not_found = source ${pkgs.nix-index}/etc/profile.d/command-not-found.nu
+    '';
+  };
+```
+
 ## Contributing
 If you find any missing features that you would like to implement, I'm very happy about any PRs! You can also create an issue first if the feature is more complex so we can discuss possible implementations.
 

--- a/command-not-found.nu
+++ b/command-not-found.nu
@@ -1,0 +1,40 @@
+{ |cmd_name|
+  let install = { |pkgs|
+    $pkgs | each {|pkg| $"  nix shell nixpkgs#($pkg)" }
+  }
+  let run_once = { |pkgs|
+    $pkgs | each {|pkg| $"  nix shell nixpkgs#($pkg) --command '($cmd_name) ...'" }
+  }
+  let single_pkg = { |pkg|
+    let lines = [
+      $"The program '($cmd_name)' is currently not installed."
+      ""
+      "You can install it by typing:"
+      (do $install [$pkg] | get 0)
+      ""
+      "Or run it once with:"
+      (do $run_once [$pkg] | get 0)
+    ]
+    $lines | str join "\n"
+  }
+  let multiple_pkgs = { |pkgs|
+    let lines = [
+      $"The program '($cmd_name)' is currently not installed. It is provided by several packages."
+      ""
+      "You can install it by typing one of the following:"
+      (do $install $pkgs | str join "\n")
+      ""
+      "Or run it once with:"
+      (do $run_once $pkgs | str join "\n")
+    ]
+    $lines | str join "\n"
+  }
+  let pkgs = (@out@/bin/nix-locate --minimal --no-group --type x --type s --top-level --whole-name --at-root $"/bin/($cmd_name)" | lines)
+  let len = ($pkgs | length)
+  let ret = match $len {
+    0 => null,
+    1 => (do $single_pkg ($pkgs | get 0)),
+    _ => (do $multiple_pkgs $pkgs),
+  }
+  return $ret
+}

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
             "(examples|src)(/.*)?"
             ''Cargo\.(toml|lock)''
             ''command-not-found\.sh''
+            ''command-not-found\.nu''
           ];
 
           cargoLock = {
@@ -40,6 +41,9 @@
             substituteInPlace command-not-found.sh \
               --subst-var out
             install -Dm555 command-not-found.sh -t $out/etc/profile.d
+            substituteInPlace command-not-found.nu \
+              --subst-var out
+            install -Dm555 command-not-found.nu -t $out/etc/profile.d
           '';
 
           meta = with lib; {


### PR DESCRIPTION
Adds a `command-not-found` hook for Nushell.

Closes #264.