### PR TITLE
nix-index: don't write to cache if we read from it

### DIFF
--- a/src/bin/nix-index.rs
+++ b/src/bin/nix-index.rs
@@ -28,6 +28,7 @@ async fn update_index(args: &Args) -> Result<()> {
     } else {
         None
     };
+    let using_cache = cached.is_some();
 
     eprintln!("+ querying available packages");
     let fetcher = Fetcher::new(CACHE_URL.to_string()).map_err(Error::ParseProxy)?;
@@ -101,7 +102,7 @@ async fn update_index(args: &Args) -> Result<()> {
     }
     eprintln!();
 
-    if args.path_cache {
+    if args.path_cache && !using_cache {
         eprintln!("+ writing path cache");
         let mut output = io::BufWriter::new(File::create("paths.cache").map_err(|e| {
             Error::WritePathsCache {


### PR DESCRIPTION
this makes it possible to use a read-only cache
(e.g. from `/nix/store`). Also saves some useless writing if we use the cache, since we would've written to the cache with its own contents