### PR TITLE
Add --substituter option

### DIFF
--- a/src/bin/nix-channel-index.rs
+++ b/src/bin/nix-channel-index.rs
@@ -7,15 +7,15 @@ use std::process;
 
 use clap::Parser;
 use futures::{future, StreamExt};
+use nix_index::errors::*;
 use nix_index::files::{FileNode, FileType};
 use nix_index::hydra::Fetcher;
 use nix_index::listings;
-use nix_index::{errors::*, CACHE_URL};
 use rusqlite::Connection;
 
 /// The main function of this module: creates a new command-not-found database.
 async fn update_index(args: &Args) -> Result<()> {
-    let fetcher = Fetcher::new(CACHE_URL.to_string()).map_err(Error::ParseProxy)?;
+    let fetcher = Fetcher::new(args.substituter.to_string()).map_err(Error::ParseProxy)?;
     let connection = Connection::open_in_memory().map_err(|e| Error::CreateDatabase {
         path: args.output.clone(),
         source: Box::new(e),
@@ -196,6 +196,10 @@ struct Args {
     /// Systems to include in generated database
     #[clap(short = 's', long = "platform")]
     systems: Option<Vec<String>>,
+
+    /// The substituter (binary cache) URL to query
+    #[clap(long, default_value = "https://cache.nixos.org")]
+    substituter: String,
 
     /// Show a stack trace in the case of a Nix evaluation error
     #[clap(long)]

--- a/src/bin/nix-index.rs
+++ b/src/bin/nix-index.rs
@@ -14,7 +14,6 @@ use nix_index::files::FileTree;
 use nix_index::hydra::Fetcher;
 use nix_index::listings::{self, try_load_paths_cache};
 use nix_index::package::StorePath;
-use nix_index::CACHE_URL;
 use separator::Separatable;
 
 /// The main function of this module: creates a new nix-index database.
@@ -30,7 +29,7 @@ async fn update_index(args: &Args) -> Result<()> {
     };
 
     eprintln!("+ querying available packages");
-    let fetcher = Fetcher::new(CACHE_URL.to_string()).map_err(Error::ParseProxy)?;
+    let fetcher = Fetcher::new(args.substituter.to_string()).map_err(Error::ParseProxy)?;
     let (files, watch) = match cached {
         Some((f, w)) => (Either::Left(f), w),
         None => {
@@ -149,6 +148,10 @@ struct Args {
     /// Specify system platform for which to build the index, accepted by nix-env --argstr system
     #[clap(short = 's', long, value_name = "platform")]
     system: Option<String>,
+
+    /// The substituter (binary cache) URL to query
+    #[clap(long, default_value = "https://cache.nixos.org")]
+    substituter: String,
 
     /// Zstandard compression level
     #[clap(short, long = "compression", default_value = "22")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,3 @@ pub mod nixpkgs;
 pub mod package;
 pub mod util;
 pub mod workset;
-
-/// The URL of the binary cache that we use to fetch file listings and references.
-///
-/// Hardcoded for now, but may be made a configurable option in the future.
-pub const CACHE_URL: &str = "https://cache.nixos.org";


### PR DESCRIPTION
This allows nix-index to e.g. work offline with custom substituter.

Fixes https://github.com/nix-community/nix-index/issues/125.
