### PR TITLE
drop xorg

### DIFF
--- a/src/listings.rs
+++ b/src/listings.rs
@@ -23,8 +23,7 @@ use crate::workset::{WorkSet, WorkSetHandle, WorkSetWatch};
 //
 // We only need sets that are not marked "recurseIntoAttrs" here, since if they are,
 // they are already part of normal_paths.
-pub const EXTRA_SCOPES: [&str; 6] = [
-    "xorg",
+pub const EXTRA_SCOPES: [&str; 5] = [
     "haskellPackages",
     "rPackages",
     "nodePackages",


### PR DESCRIPTION
It's a deprecated alias and now the missing xorg was even breaking channel updates.