### PR TITLE
dependabot: enable cooldown for nix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,10 +25,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    # TODO: enable cooldowns once upstream bug is fixed
-    # https://github.com/dependabot/dependabot-core/pull/14829
-    # cooldown:
-    #   default-days: 7
+    cooldown:
+      default-days: 7
     groups:
       nix:
         patterns: ["*"]


### PR DESCRIPTION
it's working now: https://github.com/figsoda/unnix/pull/56

probably fixed by https://github.com/dependabot/dependabot-core/pull/14840, thank you @JamieMagee!