### PR TITLE
Supplement Hydra data with `meta.mainProgram`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "owo-colors",
+ "quick-xml",
  "rayon",
  "regex",
  "regex-syntax",
@@ -1251,7 +1252,6 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "xdg",
- "xml-rs",
  "xz2",
  "zstd",
 ]
@@ -1376,6 +1376,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2719,21 +2729,6 @@ name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
-
-[[package]]
-name = "xml"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
-
-[[package]]
-name = "xml-rs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
-dependencies = [
- "xml",
-]
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ memchr = "2.7.2"
 num_cpus = "1.16.0"
 indexmap = "2.14.0"
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }
+quick-xml = { version = "0.40.1", features = ["serialize"] }
 rayon = "1.12.0"
 regex = "1.10.4"
 regex-syntax = "0.8.5"
@@ -46,7 +47,6 @@ serde_json = "1.0.150"
 thiserror = "2.0.12"
 tokio-retry = "0.3.1"
 xdg = "3.0.0"
-xml-rs = "1.0.0"
 xz2 = "0.1.7"
 zstd = { version = "0.13.3", features = [ "zstdmt" ] }
 

--- a/src/bin/nix-channel-index.rs
+++ b/src/bin/nix-channel-index.rs
@@ -72,6 +72,7 @@ async fn update_index(args: &Args) -> Result<()> {
         systems,
         &args.extra_scopes,
         args.show_trace,
+        true, // Synthesize a listing for `meta.mainProgram` under `bin/` when appropriate
     )?;
 
     // Treat request errors as if the file list were missing

--- a/src/bin/nix-index.rs
+++ b/src/bin/nix-index.rs
@@ -41,6 +41,7 @@ async fn update_index(args: &Args) -> Result<()> {
                 vec![args.system.as_deref()],
                 &args.extra_scopes,
                 args.show_trace,
+                !args.no_main_program,
             )?;
             (Either::Right(f), w)
         }
@@ -162,6 +163,10 @@ struct Args {
     /// Only add paths starting with PREFIX (e.g. `/bin/`)
     #[clap(long, default_value = "")]
     filter_prefix: String,
+
+    /// Do not synthesize a listing for `meta.mainProgram` under `/bin/`
+    #[clap(long)]
+    no_main_program: bool,
 
     /// Store and load results of fetch phase in a file called paths.cache. This speeds up testing
     /// different database formats / compression.

--- a/src/listings.rs
+++ b/src/listings.rs
@@ -153,11 +153,14 @@ pub fn fetch<'a>(
     // Collect results in parallel.
     let all_paths = all_queries
         .par_iter()
-        .flat_map_iter(|&(system, scope)| {
+        .map(|&(system, scope)| {
             nixpkgs::query_packages(nixpkgs, system, scope.as_deref(), show_trace)
         })
-        .collect::<std::result::Result<_, nixpkgs::Error>>()
-        .map_err(|e| Error::QueryPackages { source: e })?;
+        .collect::<std::result::Result<Vec<nixpkgs::Packages>, nixpkgs::Error>>()
+        .map_err(|e| Error::QueryPackages { source: e })?
+        .into_iter()
+        .flatten()
+        .collect();
 
     Ok(fetch_listings_impl(fetcher, jobs, all_paths))
 }

--- a/src/listings.rs
+++ b/src/listings.rs
@@ -1,16 +1,18 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io;
 use std::iter::FromIterator;
 
-use futures::{Stream, StreamExt, TryFutureExt};
+use futures::{Stream, StreamExt};
 use indexmap::map::Entry;
 use indexmap::IndexMap;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use serde_bytes::ByteBuf;
 
 use crate::errors::{Error, Result};
 use crate::files::FileTree;
 use crate::hydra::Fetcher;
-use crate::nixpkgs;
+use crate::nixpkgs::{self, PackageOutput};
 use crate::package::StorePath;
 use crate::workset::{WorkSet, WorkSetHandle, WorkSetWatch};
 
@@ -21,6 +23,21 @@ use crate::workset::{WorkSet, WorkSetHandle, WorkSetWatch};
 pub trait FileListingStream: Stream<Item = Result<Option<(StorePath, String, FileTree)>>> {}
 impl<T> FileListingStream for T where T: Stream<Item = Result<Option<(StorePath, String, FileTree)>>>
 {}
+
+/// Builds a synthetic file listing containing just `/bin/$main_program`.
+///
+/// This can be used to supplement the set of packages built by Hydra. Note that this function
+/// always returns zero for the size of the executable file, and an empty string for the nar.
+fn synthesize_main_program(path: StorePath, main_program: String) -> (StorePath, String, FileTree) {
+    let tree = HashMap::from([(
+        ByteBuf::from(b"bin".to_vec()),
+        FileTree::directory(HashMap::from([(
+            ByteBuf::from(main_program.into_bytes()),
+            FileTree::regular(0, true),
+        )])),
+    )]);
+    (path, String::new(), FileTree::directory(tree))
+}
 
 /// Fetches all the file listings for the full closure of the given starting set of path.
 ///
@@ -34,24 +51,24 @@ impl<T> FileListingStream for T where T: Stream<Item = Result<Option<(StorePath,
 fn fetch_listings_impl(
     fetcher: &Fetcher,
     jobs: usize,
-    starting_set: Vec<StorePath>,
+    starting_set: Vec<PackageOutput>,
 ) -> (impl FileListingStream + '_, WorkSetWatch) {
     // Create the queue that will hold all the paths that still need processing.
     // Initially, only the starting set needs processing.
 
     // We can't use FromIterator here as we want shorter paths to win
-    let mut map: IndexMap<String, StorePath> = IndexMap::with_capacity(starting_set.len());
+    let mut map: IndexMap<String, PackageOutput> = IndexMap::with_capacity(starting_set.len());
 
-    for path in starting_set {
-        let hash = path.hash().into();
+    for output in starting_set {
+        let hash = output.path.hash().into();
         match map.entry(hash) {
             Entry::Occupied(mut e) => {
-                if e.get().origin().attr.len() > path.origin().attr.len() {
-                    e.insert(path);
+                if e.get().path.origin().attr.len() > output.path.origin().attr.len() {
+                    e.insert(output);
                 }
             }
             Entry::Vacant(e) => {
-                e.insert(path);
+                e.insert(output);
             }
         };
     }
@@ -60,18 +77,20 @@ fn fetch_listings_impl(
 
     // Processes a single store path, fetching the file listing for it and
     // adding its references to the queue
-    let process = move |mut handle: WorkSetHandle<_, _>, path: StorePath| async move {
-        let Some(parsed) = fetcher
-            .fetch_references(path.clone())
-            .map_err(|e| Error::FetchReferences { path, source: e })
-            .await?
-        else {
-            return Ok(None);
+    let process = move |mut handle: WorkSetHandle<_, _>, PackageOutput { path, main_program }| async move {
+        let parsed = match fetcher.fetch_references(path.clone()).await {
+            Err(e) => return Err(Error::FetchReferences { path, source: e }),
+            Ok(Some(parsed)) => parsed,
+            Ok(None) => return Ok(main_program.map(|p| synthesize_main_program(path, p))),
         };
 
         for reference in parsed.references {
             let hash = reference.hash().into_owned();
-            handle.add_work(hash, reference);
+            let output = PackageOutput {
+                path: reference,
+                main_program: None,
+            };
+            handle.add_work(hash, output);
         }
 
         let path = parsed.store_path.clone();
@@ -83,7 +102,7 @@ fn fetch_listings_impl(
                 source: e,
             }),
             Ok(Some(files)) => Ok(Some((path, nar_path, files))),
-            Ok(None) => Ok(None),
+            Ok(None) => Ok(main_program.map(|p| synthesize_main_program(parsed.store_path, p))),
         }
     };
 
@@ -132,6 +151,7 @@ pub fn fetch<'a>(
     systems: Vec<Option<&str>>,
     extra_scopes: &[String],
     show_trace: bool,
+    main_program: bool,
 ) -> Result<(impl FileListingStream + 'a, WorkSetWatch)> {
     let mut scopes = vec![None];
     scopes.extend(
@@ -151,10 +171,10 @@ pub fn fetch<'a>(
     }
 
     // Collect results in parallel.
-    let all_paths = all_queries
+    let all_paths: nixpkgs::Packages = all_queries
         .par_iter()
         .map(|&(system, scope)| {
-            nixpkgs::query_packages(nixpkgs, system, scope.as_deref(), show_trace)
+            nixpkgs::query_packages(nixpkgs, system, scope.as_deref(), show_trace, main_program)
         })
         .collect::<std::result::Result<Vec<nixpkgs::Packages>, nixpkgs::Error>>()
         .map_err(|e| Error::QueryPackages { source: e })?

--- a/src/nixpkgs.rs
+++ b/src/nixpkgs.rs
@@ -24,12 +24,16 @@ use crate::package::{PathOrigin, StorePath};
 /// If scope is `Some(attr)`, nix-env is called with the `-A attr` argument so only packages that are a member
 /// of `attr` are returned.
 ///
+/// If `main_program` is true, nix-env is also passed `--meta` so that each package's
+/// `meta.mainProgram` is included in the output.
+///
 /// The function returns an [`IntoIterator`] over the packages returned by nix-env.
 pub fn query_packages(
     nixpkgs: &str,
     system: Option<&str>,
     scope: Option<&str>,
     show_trace: bool,
+    main_program: bool,
 ) -> Result<Packages, Error> {
     let mut cmd = Command::new("nix-env");
     cmd.arg("-qaP")
@@ -47,6 +51,13 @@ pub fn query_packages(
         .stderr(Stdio::piped())
         .stdin(Stdio::null());
 
+    if main_program {
+        // Query package meta so we can read `meta.mainProgram`, used to synthesize a
+        // `/bin/$mainProgram` listing for packages not built by Hydra. We skip it otherwise:
+        // `--meta` makes nix-env emit roughly ten times as much output.
+        cmd.arg("--meta");
+    }
+
     if let Some(system) = system {
         cmd.arg("--argstr").arg("system").arg(system);
     }
@@ -62,10 +73,16 @@ pub fn query_packages(
     run(cmd)
 }
 
-/// An [`IntoIterator`] of parsed store paths from the output of nix-env.
+#[derive(Debug)]
+pub struct PackageOutput {
+    pub path: StorePath,
+    pub main_program: Option<String>,
+}
+
+/// An [`IntoIterator`] of parsed store paths and main programs from the output of nix-env.
 ///
 /// Use `query_packages` to create a value of this type.
-pub type Packages = Vec<StorePath>;
+pub type Packages = Vec<PackageOutput>;
 
 /// Spawns the nix-env subprocess and runs the parser,
 /// waits for it to exit, and checks whether it has returned a non-zero exit code
@@ -91,7 +108,7 @@ fn run(mut cmd: Command) -> Result<Packages, Error> {
         )));
     }
 
-    Ok(parsed?.items)
+    Ok(parsed?.outputs)
 }
 
 /// A parser error that may occur during parsing `nix-env`'s output.
@@ -106,31 +123,67 @@ struct Output {
 }
 
 #[derive(Debug, Deserialize)]
+struct Meta {
+    #[serde(rename = "@name")]
+    name: String,
+    #[serde(rename = "@value")]
+    value: Option<String>,
+}
+
+fn main_program<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<String>, D::Error> {
+    Ok(Vec::<Meta>::deserialize(deserializer)?
+        .into_iter()
+        .find(|meta| meta.name == "mainProgram")
+        .and_then(|meta| meta.value))
+}
+
+#[derive(Debug, Deserialize)]
 struct Item {
     #[serde(rename = "@attrPath")]
     attr_path: String,
+    #[serde(rename = "@outputName", default)]
+    output_name: String,
     #[serde(rename = "@system")]
     system: String,
     #[serde(rename = "output", default)]
     outputs: Vec<Output>,
+    #[serde(rename = "meta", default, deserialize_with = "main_program")]
+    main_program: Option<String>,
 }
 
 impl Item {
-    fn consume<E: de::Error>(self, store_paths: &mut Vec<StorePath>) -> Result<(), E> {
+    fn consume<E: de::Error>(self, outputs: &mut Vec<PackageOutput>) -> Result<(), E> {
+        // By convention (`lib.getExe`), `meta.mainProgram` names the executable
+        // `bin/$mainProgram` in the package's "bin" output, falling back to its "out"
+        // output and then its default output (the `lib.getBin` chain `pkg.bin or pkg.out or pkg`).
+        // It is not in every output, so tag only that one.
+        let main_output: &str = if self.outputs.iter().any(|output| output.name == "bin") {
+            "bin"
+        } else if self.outputs.iter().any(|output| output.name == "out") {
+            "out"
+        } else {
+            &self.output_name
+        };
+
         for output in self.outputs {
+            let main_program = if output.name == main_output {
+                self.main_program.clone()
+            } else {
+                None
+            };
             let origin = PathOrigin {
                 attr: self.attr_path.clone(),
                 output: output.name,
                 toplevel: true,
                 system: Some(self.system.clone()),
             };
-            let store_path = StorePath::parse(origin, &output.path).ok_or_else(|| {
+            let path = StorePath::parse(origin, &output.path).ok_or_else(|| {
                 de::Error::custom(format!(
                     "store path does not match expected format /prefix/hash-name: {}",
                     output.path
                 ))
             })?;
-            store_paths.push(store_path);
+            outputs.push(PackageOutput { path, main_program });
         }
         Ok(())
     }
@@ -138,28 +191,28 @@ impl Item {
 
 #[derive(Debug, Deserialize)]
 struct Items {
-    #[serde(rename = "item", default, deserialize_with = "deserialize_items")]
-    items: Vec<StorePath>,
+    #[serde(rename = "item", default, deserialize_with = "package_outputs")]
+    outputs: Vec<PackageOutput>,
 }
 
-fn deserialize_items<'de, D: Deserializer<'de>>(
+fn package_outputs<'de, D: Deserializer<'de>>(
     deserializer: D,
-) -> Result<Vec<StorePath>, D::Error> {
+) -> Result<Vec<PackageOutput>, D::Error> {
     struct ItemsVisitor;
 
     impl<'de> Visitor<'de> for ItemsVisitor {
-        type Value = Vec<StorePath>;
+        type Value = Vec<PackageOutput>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             write!(formatter, "a sequence of `<item>` elements")
         }
 
         fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-            let mut store_paths = Vec::new();
+            let mut outputs = Vec::new();
             while let Some(item) = seq.next_element::<Item>()? {
-                item.consume(&mut store_paths)?;
+                item.consume(&mut outputs)?;
             }
-            Ok(store_paths)
+            Ok(outputs)
         }
     }
 

--- a/src/nixpkgs.rs
+++ b/src/nixpkgs.rs
@@ -5,12 +5,11 @@
 //! and hashes.
 use std::error;
 use std::fmt;
-use std::io::{self, Read};
-use std::process::{Child, ChildStdout, Command, Stdio};
+use std::io::{self, BufReader};
+use std::process::{Command, Stdio};
 
-use xml;
-use xml::common::{Position, TextPosition};
-use xml::reader::{EventReader, XmlEvent};
+use serde::de::{self, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
 
 use crate::package::{PathOrigin, StorePath};
 
@@ -25,13 +24,13 @@ use crate::package::{PathOrigin, StorePath};
 /// If scope is `Some(attr)`, nix-env is called with the `-A attr` argument so only packages that are a member
 /// of `attr` are returned.
 ///
-/// The function returns an Iterator over the packages returned by nix-env.
+/// The function returns an [`IntoIterator`] over the packages returned by nix-env.
 pub fn query_packages(
     nixpkgs: &str,
     system: Option<&str>,
     scope: Option<&str>,
     show_trace: bool,
-) -> PackagesQuery<ChildStdout> {
+) -> Result<Packages, Error> {
     let mut cmd = Command::new("nix-env");
     cmd.arg("-qaP")
         .arg("--out-path")
@@ -60,354 +59,111 @@ pub fn query_packages(
         cmd.arg("--show-trace");
     }
 
-    PackagesQuery {
-        parser: None,
-        child: None,
-        cmd: Some(cmd),
-    }
+    run(cmd)
 }
 
-/// An iterator that parses the output of nix-env and returns parsed store paths.
+/// An [`IntoIterator`] of parsed store paths from the output of nix-env.
 ///
 /// Use `query_packages` to create a value of this type.
-pub struct PackagesQuery<R: Read> {
-    parser: Option<PackagesParser<R>>,
-    child: Option<Child>,
-    cmd: Option<Command>,
-}
+pub type Packages = Vec<StorePath>;
 
-impl PackagesQuery<ChildStdout> {
-    /// Spawns the nix-env subprocess and initializes the parser.
-    ///
-    /// If the subprocess was already spawned, does nothing.
-    fn ensure_initialized(&mut self) -> Result<(), Error> {
-        if let Some(mut cmd) = self.cmd.take() {
-            let mut child = cmd.spawn()?;
+/// Spawns the nix-env subprocess and runs the parser,
+/// waits for it to exit, and checks whether it has returned a non-zero exit code
+/// (= failed with an error).
+///
+/// If the exit code was non-zero, returns `Err(err)`, else it returns `Ok`.
+fn run(mut cmd: Command) -> Result<Packages, Error> {
+    let mut child = cmd.spawn()?;
+    let stdout = child.stdout.take().expect("should have stdout pipe");
+    let parsed: Result<Items, _> = quick_xml::de::from_reader(BufReader::new(stdout));
 
-            let stdout = child.stdout.take().expect("should have stdout pipe");
-            let parser = PackagesParser::new(stdout);
+    // Even when the parser throws an error, we first wait for the subprocess to exit.
+    //
+    // If the subprocess returned an error, then the parser probably tried to parse garbage output
+    // so we will ignore the parser error and instead return the error printed by the subprocess.
+    let result = child.wait_with_output()?;
+    if !result.status.success() {
+        let message = String::from_utf8_lossy(&result.stderr);
 
-            self.child = Some(child);
-            self.parser = Some(parser);
-        }
-        Ok(())
+        return Err(Error::Command(format!(
+            "nix-env failed with {}:\n{}",
+            result.status, message,
+        )));
     }
 
-    /// Waits for the subprocess to exit and checks whether it has returned a non-zero exit code
-    /// (= failed with an error).
-    ///
-    /// If the exit code was non-zero, returns Some(err), else it returns None.
-    fn check_error(&mut self) -> Option<Error> {
-        let mut run = || {
-            let child = match self.child.take() {
-                Some(c) => c,
-                None => return Ok(()),
-            };
-            let result = child.wait_with_output()?;
-
-            if !result.status.success() {
-                let message = String::from_utf8_lossy(&result.stderr);
-
-                return Err(Error::Command(format!(
-                    "nix-env failed with {}:\n{}",
-                    result.status, message,
-                )));
-            }
-
-            Ok(())
-        };
-
-        run().err()
-    }
-}
-
-impl Iterator for PackagesQuery<ChildStdout> {
-    type Item = Result<StorePath, Error>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Err(e) = self.ensure_initialized() {
-            return Some(Err(e));
-        }
-        self.parser.take().and_then(|mut parser| {
-            parser
-                .next()
-                .map(|v| {
-                    self.parser = Some(parser);
-                    // When the parser throws an error, we first wait for the subprocess to exit.
-                    //
-                    // If the subprocess returned an error, then the parser probably tried to parse garbage output
-                    // so we will ignore the parser error and instead return the error printed by the subprocess.
-                    v.map_err(|e| self.check_error().unwrap_or_else(|| Error::from(e)))
-                })
-                .or_else(|| {
-                    self.parser = None;
-                    // At the end, we should check if the subprocess exited successfully.
-                    self.check_error().map(Err)
-                })
-        })
-    }
-}
-
-/// Parses the XML output of `nix-env` and returns individual store paths.
-struct PackagesParser<R: Read> {
-    events: EventReader<R>,
-    current_item: Option<(String, String)>,
+    Ok(parsed?.items)
 }
 
 /// A parser error that may occur during parsing `nix-env`'s output.
-#[derive(Debug)]
-pub struct ParserError {
-    position: TextPosition,
-    kind: ParserErrorKind,
+type ParserError = quick_xml::DeError;
+
+#[derive(Debug, Deserialize)]
+struct Output {
+    #[serde(rename = "@name")]
+    name: String,
+    #[serde(rename = "@path")]
+    path: String,
 }
 
-/// Enumerates all possible error kinds that may occur during parsing.
-#[derive(Debug)]
-pub enum ParserErrorKind {
-    /// Found an element with the tag `element_name` that should only occur inside
-    /// elements with the tag `expected_parent` but it occurred as child of a different parent.
-    MissingParent {
-        element_name: String,
-        expected_parent: String,
-    },
-
-    /// An element occurred as a child of `found_parent`, but
-    /// we know that elements with the tag `element_name` should never have that as
-    /// a parent.
-    ParentNotAllowed {
-        element_name: String,
-        found_parent: String,
-    },
-
-    /// The required attribute `attribute_name` was missing on an element with the tag `element_name`.
-    MissingAttribute {
-        element_name: String,
-        attribute_name: String,
-    },
-
-    /// Found the end tag for `element_name` without a matching start tag.
-    MissingStartTag { element_name: String },
-
-    /// An XML syntax error.
-    XmlError { error: xml::reader::Error },
-
-    /// A store path in the output of `nix-env` could not be parsed. All valid store paths
-    /// need to match the format `$(STOREDIR)$(HASH)-$(NAME)`.
-    InvalidStorePath { path: String },
+#[derive(Debug, Deserialize)]
+struct Item {
+    #[serde(rename = "@attrPath")]
+    attr_path: String,
+    #[serde(rename = "@system")]
+    system: String,
+    #[serde(rename = "output", default)]
+    outputs: Vec<Output>,
 }
 
-impl fmt::Display for ParserError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        use self::ParserErrorKind::*;
-        write!(f, "error at {}: ", self.position)?;
-        match self.kind {
-            MissingParent {
-                ref element_name,
-                ref expected_parent,
-            } => {
-                write!(
-                    f,
-                    "element {} appears outside of expected parent {}",
-                    element_name, expected_parent
-                )
-            }
-            ParentNotAllowed {
-                ref element_name,
-                ref found_parent,
-            } => {
-                write!(
-                    f,
-                    "element {} must not appear as child of {}",
-                    element_name, found_parent
-                )
-            }
-            MissingAttribute {
-                ref element_name,
-                ref attribute_name,
-            } => {
-                write!(
-                    f,
-                    "element {} must have an attribute named {}",
-                    element_name, attribute_name
-                )
-            }
-            MissingStartTag { ref element_name } => {
-                write!(f, "element {} does not have a start tag", element_name)
-            }
-            XmlError { ref error } => write!(f, "document not well-formed: {}", error),
-            InvalidStorePath { ref path } => {
-                write!(
-                    f,
+impl Item {
+    fn consume<E: de::Error>(self, store_paths: &mut Vec<StorePath>) -> Result<(), E> {
+        for output in self.outputs {
+            let origin = PathOrigin {
+                attr: self.attr_path.clone(),
+                output: output.name,
+                toplevel: true,
+                system: Some(self.system.clone()),
+            };
+            let store_path = StorePath::parse(origin, &output.path).ok_or_else(|| {
+                de::Error::custom(format!(
                     "store path does not match expected format /prefix/hash-name: {}",
-                    path
-                )
-            }
+                    output.path
+                ))
+            })?;
+            store_paths.push(store_path);
         }
+        Ok(())
     }
 }
 
-impl<R: Read> PackagesParser<R> {
-    /// Creates a new parser that reads the `nix-env` XML output from the given reader.
-    pub fn new(reader: R) -> PackagesParser<R> {
-        PackagesParser {
-            events: EventReader::new(reader),
-            current_item: None,
-        }
-    }
-
-    /// Shorthand for exiting with an error at the current position.
-    fn err(&self, kind: ParserErrorKind) -> ParserError {
-        ParserError {
-            position: self.events.position(),
-            kind,
-        }
-    }
-
-    /// Tries to read the next `StorePath` from the reader or fail with an error
-    /// if there was a parse failure.
-    ///
-    /// Returns Ok(None) if the end of the stream was reached.
-    ///
-    /// This function is like `.next` from `Iterator`, but allows us to use `try! / ?` since it
-    /// returns `Result<Option<...>, ...>` instead of `Option<Result<..., ...>>`.
-    fn next_err(&mut self) -> Result<Option<StorePath>, ParserError> {
-        use self::ParserErrorKind::*;
-        use self::XmlEvent::*;
-
-        loop {
-            let event = self
-                .events
-                .next()
-                .map_err(|e| self.err(XmlError { error: e }))?;
-            match event {
-                StartElement {
-                    name: element_name,
-                    attributes,
-                    ..
-                } => {
-                    if element_name.local_name == "item" {
-                        if self.current_item.is_some() {
-                            return Err(self.err(ParentNotAllowed {
-                                element_name: "item".to_string(),
-                                found_parent: "item".to_string(),
-                            }));
-                        }
-
-                        let mut attr_path = None;
-                        let mut system = None;
-
-                        for attr in attributes {
-                            if attr.name.local_name == "attrPath" {
-                                attr_path = Some(attr.value);
-                                continue;
-                            }
-
-                            if attr.name.local_name == "system" {
-                                system = Some(attr.value);
-                                continue;
-                            }
-                        }
-
-                        let attr_path = attr_path.ok_or_else(|| {
-                            self.err(MissingAttribute {
-                                element_name: "item".into(),
-                                attribute_name: "attrPath".into(),
-                            })
-                        })?;
-
-                        let system = system.ok_or_else(|| {
-                            self.err(MissingAttribute {
-                                element_name: "item".into(),
-                                attribute_name: "system".into(),
-                            })
-                        })?;
-
-                        self.current_item = Some((attr_path, system));
-                        continue;
-                    }
-
-                    if element_name.local_name == "output" {
-                        if let Some((item, system)) = self.current_item.clone() {
-                            let mut output_name = None;
-                            let mut output_path = None;
-
-                            for attr in attributes {
-                                if attr.name.local_name == "name" {
-                                    output_name = Some(attr.value);
-                                    continue;
-                                }
-
-                                if attr.name.local_name == "path" {
-                                    output_path = Some(attr.value);
-                                    continue;
-                                }
-                            }
-
-                            let output_name = output_name.ok_or_else(|| {
-                                self.err(MissingAttribute {
-                                    element_name: "output".into(),
-                                    attribute_name: "name".into(),
-                                })
-                            })?;
-
-                            let output_path = output_path.ok_or_else(|| {
-                                self.err(MissingAttribute {
-                                    element_name: "output".into(),
-                                    attribute_name: "path".into(),
-                                })
-                            })?;
-
-                            let origin = PathOrigin {
-                                attr: item,
-                                output: output_name,
-                                toplevel: true,
-                                system: Some(system),
-                            };
-                            let store_path = StorePath::parse(origin, &output_path);
-                            let store_path = store_path
-                                .ok_or_else(|| self.err(InvalidStorePath { path: output_path }))?;
-
-                            return Ok(Some(store_path));
-                        } else {
-                            return Err(self.err(MissingParent {
-                                element_name: "output".into(),
-                                expected_parent: "item".into(),
-                            }));
-                        }
-                    }
-                }
-
-                EndElement { name: element_name } => {
-                    if element_name.local_name == "item" {
-                        if self.current_item.is_none() {
-                            return Err(self.err(MissingStartTag {
-                                element_name: "item".into(),
-                            }));
-                        }
-                        self.current_item = None
-                    }
-                }
-
-                EndDocument => break,
-
-                _ => {}
-            }
-        }
-
-        Ok(None)
-    }
+#[derive(Debug, Deserialize)]
+struct Items {
+    #[serde(rename = "item", default, deserialize_with = "deserialize_items")]
+    items: Vec<StorePath>,
 }
 
-impl<R: Read> Iterator for PackagesParser<R> {
-    type Item = Result<StorePath, ParserError>;
+fn deserialize_items<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<StorePath>, D::Error> {
+    struct ItemsVisitor;
 
-    fn next(&mut self) -> Option<Result<StorePath, ParserError>> {
-        match self.next_err() {
-            Err(e) => Some(Err(e)),
-            Ok(Some(i)) => Some(Ok(i)),
-            Ok(None) => None,
+    impl<'de> Visitor<'de> for ItemsVisitor {
+        type Value = Vec<StorePath>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a sequence of `<item>` elements")
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let mut store_paths = Vec::new();
+            while let Some(item) = seq.next_element::<Item>()? {
+                item.consume(&mut store_paths)?;
+            }
+            Ok(store_paths)
         }
     }
+
+    deserializer.deserialize_seq(ItemsVisitor)
 }
 
 /// Enumeration of all the possible errors that may happen during querying the packages.


### PR DESCRIPTION
This PR resolves #317, enabling nix-locate and downstream tools like comma to see packages that Hydra doesn't build:

```
$ nix-locate --at-root --whole-name /bin/nh
nh-unwrapped.out                             14,301,472 x /nix/store/j5lpv7cdjxs35if2b4snqkgxc4q0ya6a-nh-unwrapped-4.3.2/bin/nh
nh.out                                                0 x /nix/store/k9c04vx63x91fa3k147g5hi7k0ppns80-nh-4.3.2/bin/nh
```

I would strongly recommend reviewing the two commits of this PR separately.

The first commit rewrites the parser for [`nix-env --query --xml`](https://nix.dev/manual/nix/2.34/command-ref/nix-env/query). I did this because I found the existing parser extremely unwieldy and difficult to modify. The rewrite uses Serde via [quick-xml](https://crates.io/crates/quick-xml), is significantly less code, and is roughly 4x faster than before. While the new double usage of `.collect` in `listings::fetch` may look a bit suspicious, the memory usage is not noticeably different from before.

The second commit implements the actual feature: passing the `--meta` flag to that `nix-env --query` command so that we can extract `meta.mainProgram` when it's available. That is then threaded through along with the store path, and in cases where Hydra doesn't have it, a synthesized `/bin/$mainProgram` file listing is created. This whole thing can be turned off via `nix-index --no-main-program`, which simply doesn't add the `--meta` flag and so no `meta.mainProgram` entries are created in the first place.

A few notes/questions I have for the reviewer(s):

1. Is it alright for these two commits to be put together into this one PR, or would the first commit need to be merged as a separate PR first? Or is the parser rewrite simply a no-go and I should change this PR to fit into the existing parser structure?

2. Should this PR modify `CHANGELOG.md`?

3. Is it fine that we say the size of the executable file is zero bytes, and give an empty string for the nar? It seems like the latter is only used for debugging (and thus would never be used in this case anyway), but I wanted to double-check. I believe the former is only displayed by nix-locate (see the example output above); it does look _slightly_ weird, so I wonder if it'd be worth it to change `FileNode::Regular`'s `size` field from `u64` to `Option<u64>`.

4. This PR doesn't use quick-xml in such a way that the error messages include line or column numbers. Is that fine? If not, I could make the code slightly uglier and use [`Reader::error_position`](https://docs.rs/quick-xml/0.40.1/quick_xml/reader/struct.Reader.html#method.error_position) to report the byte offset of the deserialization error. Or if we really need line and column specifically, I suppose we could keep track of where all the newlines are when we stream the data, and then convert the byte offset using those. I wasn't sure how much this matters, though, so I kept the code simple initially.

5. While the rewritten parser from the first commit is about 4x faster than the previous parser, adding the `--meta` flag causes the XML output to be 10x bigger, and in the end, when we feed that bigger XML into the new parser, it's about 3x slower than feeding the smaller XML into the original parser. I'm guessing this is fine since parsing this XML isn't really a bottleneck?

6. I don't love that now `nixpkgs::query_packages` and `listings::fetch` each have _two_ boolean flags passed positionally. But I'm also not sure it's worth it to create a `struct` in this case.