### PR TITLE
hydra: support zstd-compressed .ls listings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,8 @@ checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "brotli",
  "compression-core",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ owo-colors = { version = "4.0.0", features = ["supports-colors"] }
 rayon = "1.12.0"
 regex = "1.10.4"
 regex-syntax = "0.8.5"
-reqwest = { version = "0.13.4", features = [ "brotli" ] }
+reqwest = { version = "0.13.4", features = [ "brotli", "zstd" ] }
 separator = "0.4.1"
 serde = { version = "1.0.198", features = [ "derive" ] }
 serde_bytes = "0.11.14"

--- a/src/hydra.rs
+++ b/src/hydra.rs
@@ -270,20 +270,30 @@ impl Fetcher {
         let name = format!("{}.json", path.hash());
 
         let (url, body) = self.fetch(url_generic).await?;
-        let contents = match body {
+        let raw = match body {
             Some(v) => v,
             None => {
                 let (_, Some(body)) = self.fetch(url_xz.clone()).await? else {
                     return Ok(None);
                 };
+                body
+            }
+        };
 
+        // cache.nixos.org keeps the `.ls` name but serves compressed bodies with
+        // no Content-Encoding header, so sniff the magic bytes to decode.
+        let contents = match raw.as_slice() {
+            [0x28, 0xb5, 0x2f, 0xfd, ..] => {
+                zstd::decode_all(&raw[..]).map_err(|e| Error::Decode { url: e.to_string() })?
+            }
+            [0xfd, b'7', b'z', b'X', b'Z', 0x00, ..] => {
                 let mut unpacked = vec![];
-                XzDecoder::new(&body[..])
+                XzDecoder::new(&raw[..])
                     .read_to_end(&mut unpacked)
                     .map_err(|e| Error::Decode { url: e.to_string() })?;
-
                 unpacked
             }
+            _ => raw,
         };
 
         let now = Instant::now();


### PR DESCRIPTION
cache.nixos.org serves `.ls` listings compressed with zstd under the plain `.ls` name, and existing objects carry no `Content-Encoding` header.

Sniff the body magic bytes to decode zstd, xz or plain JSON, and enable the reqwest `zstd` feature so listings with a `Content-Encoding: zstd` header decode directly.

Tested against the cache: the `hello` listing decodes to 148 entries.