### PR TITLE
feat: filter by /bin/ by default when generating index

### DIFF
--- a/src/bin/nix-index.rs
+++ b/src/bin/nix-index.rs
@@ -160,7 +160,7 @@ struct Args {
     show_trace: bool,
 
     /// Only add paths starting with PREFIX (e.g. `/bin/`)
-    #[clap(long, default_value = "")]
+    #[clap(long, default_value = "/bin/")]
     filter_prefix: String,
 
     /// Store and load results of fetch phase in a file called paths.cache. This speeds up testing


### PR DESCRIPTION
FIXES: #319

By default, nix-index will now generate a filtered database containing only executables under `/bin/`, which is significantly faster to build and query. Users can opt-out to build an unfiltered database by passing `--filter-prefix ""`.