### PR TITLE
doc(README): add details & requirements on database building

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # nix-index
 ## A files database for nixpkgs
-**nix-index** is a tool to quickly locate the package providing a certain file in [`nixpkgs`](https://github.com/NixOS/nixpkgs). It indexes built derivations found in binary caches. 
+**nix-index** is a tool to quickly locate the package providing a certain file in [`nixpkgs`](https://github.com/NixOS/nixpkgs).
+It holds a local database which is built by
+evaluating all packages in nixpkgs
+and then indexing their built derivations found in binary caches.
 
 ###### Demo
 
@@ -16,6 +19,9 @@ camlistore.out                                7,938,952 x /nix/store/xn5ivjdyslx
 ## Installation
 
 ### Flakes
+
+> [!NOTE]
+> Creating the database may take some time & resources, see [Usage](#Usage) section below.
 
 1. create the database:
 
@@ -48,7 +54,14 @@ $ nix-env -iA nixos.nix-index
 ```
 
 ## Usage
-First, you need to generate an index by running `nix-index` (it takes around 5 minutes) . Then, you can use `nix-locate pattern`. For more information, see `nix-locate --help` and `nix-index --help`.
+
+> [!NOTE]
+> Building the database locally may take up to **2 hours**,
+> mostly independent from your hardware configuration,
+> and requires roughly **10-12 GiB of RAM** as of July 2026.
+
+First, you need to generate an index by running `nix-index`.
+Then, you can use `nix-locate pattern`. For more information, see `nix-locate --help` and `nix-index --help`.
 
 ### Use pre-generated database
 


### PR DESCRIPTION
- Precise description about how the database is built.
- Add notes explaining required time & RAM for building database locally, replacing old hint & making them more obvious.
- Further point out independency from hardware configuration (see reasoning below)
- Add hint about RAM usage esp. cause RAM is a hard-limited resource.

Former commit 97e309f71decd55e11040a396e081c66793a268b from 7 years ago stated a time of roughly 5 minutes, but today my laptop (Intel i5-10310U, 16 GiB RAM) needed 84 minutes. Probably also because nixpkgs got bigger in the last 7 years. Afterwards I also measured the execution time on a server I had available (VM on AMD EPYC 7713, 128 GiB RAM). Despite more performant hardware & better connectivity, the server needed 116 minutes. Measured the time on 2026-07-11 with nix-index 1.10.0 as served on NixOS 26.05 (NixOS/nixpkgs@0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c).